### PR TITLE
Recreated Internal Error

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Database\Factories\User\PostFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Post extends Model
+{
+    use HasFactory;
+
+    protected $guarded = ['id'];
+
+    public static function newFactory(): PostFactory
+    {
+        return PostFactory::new();
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -3,6 +3,8 @@
 namespace App;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+
+use Database\Factories\User\UserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -42,4 +44,9 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    public static function newFactory(): UserFactory
+    {
+        return UserFactory::new();
+    }
 }

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -16,7 +16,7 @@ class PostFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id' => User::factory(),
+            'user_id' => User::factory(), # If this line is commented out, then phpstan will not error.
         ];
     }
 }

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Str;
 
 class PostFactory extends Factory
 {
-    protected $models = Post::class;
+    protected $model = Post::class;
 
     public function definition(): array
     {

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories\User;
+
+use App\Models\Post;
+use App\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class PostFactory extends Factory
+{
+    protected $models = Post::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/database/factories/user/UserFactory.php
+++ b/database/factories/user/UserFactory.php
@@ -15,8 +15,8 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => Str::slug($this->faker->firstName()) . ' ' . Str::slug($this->faker->lastName()),
-            'email' => $this->faker->unique()->safeEmail(),
+            'name' => fake()->name(),
+            'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
         ];
     }

--- a/database/factories/user/UserFactory.php
+++ b/database/factories/user/UserFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories\User;
+
+use App\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class UserFactory extends Factory
+{
+    protected $models = User::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => Str::slug($this->faker->firstName()) . ' ' . Str::slug($this->faker->lastName()),
+            'email' => $this->faker->unique()->safeEmail(),
+            'email_verified_at' => now(),
+        ];
+    }
+}

--- a/database/factories/user/UserFactory.php
+++ b/database/factories/user/UserFactory.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Str;
 
 class UserFactory extends Factory
 {
-    protected $models = User::class;
+    protected $model = User::class;
 
     public function definition(): array
     {


### PR DESCRIPTION
Setup the user model to have a regular Laravel factory and called the static `factory` function on the user model in the `PostFactory` to recreate the internal error.

User model already contains a deprecated legacy factory from a previous commit.